### PR TITLE
Update packlist

### DIFF
--- a/Platform_FVP_Corstone_SSE-300_Ethos-U55/packlist
+++ b/Platform_FVP_Corstone_SSE-300_Ethos-U55/packlist
@@ -3,6 +3,6 @@ https://github.com/MDK-Packs/tensorflow-pack/releases/download/0.4/tensorflow.ki
 https://github.com/MDK-Packs/tensorflow-pack/releases/download/0.4/tensorflow.ruy.0.4.0.pack
 https://github.com/MDK-Packs/tensorflow-pack/releases/download/0.4/tensorflow.gemmlowp.0.4.0.pack
 https://github.com/MDK-Packs/tensorflow-pack/releases/download/0.4/tensorflow.tensorflow-lite-micro.0.4.0.pack
-https://github.com/MDK-Packs/tensorflow-pack/releases/download/0.4/Arm.ethos-u-core-driver.0.4.0.pack
+https://github.com/MDK-Packs/tensorflow-pack/releases/download/0.4/ARM.ethos-u-core-driver.0.4.0.pack
 https://www.keil.com/pack/ARM.CMSIS.5.8.0.pack
 https://keilpack.azureedge.net/pack/ARM.V2M_MPS3_SSE_300_BSP.1.2.0.pack


### PR DESCRIPTION
`Arm.ethos-u-core-driver` vendor's name capitalization is not coherent with [pack release](https://github.com/MDK-Packs/tensorflow-pack/releases/download/0.4/ARM.ethos-u-core-driver.0.4.0.pack). 